### PR TITLE
Fix the external-links plugin

### DIFF
--- a/_plugins/external-links.rb
+++ b/_plugins/external-links.rb
@@ -101,7 +101,7 @@ module Jekyll
         end
       end
 
-      doc.to_s
+      doc.at('body').inner_html
     end
 
   end


### PR DESCRIPTION
So that it doesn't include an html tag inside the body